### PR TITLE
[chore] added ollama cpu

### DIFF
--- a/ollama.yaml
+++ b/ollama.yaml
@@ -12,6 +12,26 @@ ollama:
   containers:
     ollama:
       image: ollama/ollama:latest
+  services:
+    web:
+      container: ollama
+      protocol: tcp
+      port: 11434
+      host-port: 11434
+
+ollama-cpu:
+  defines: runnable
+  metadata:
+    website: https://ollama.ai
+    name: Ollama
+    icon: https://avatars.githubusercontent.com/u/151674099?s=48&v=4
+    publisher: monk.io
+    source: https://github.com/ollama/ollama
+    tags: ai, llm
+    description: Get up and running with large language models, locally.
+  containers:
+    ollama:
+      image: ollama/ollama:latest
       resources:
         requests:
           nvidia.com/gpu: 1


### PR DESCRIPTION
This pull request updates the `ollama.yaml` configuration to add a new runnable definition for `ollama`, including metadata and container/service setup. The changes make it easier to deploy and run Ollama locally with clear metadata and service definitions.

**New Ollama runnable definition and configuration:**

* Added a new `ollama` runnable with detailed metadata, including website, name, icon, publisher, source, tags, and description.
* Defined a container for `ollama` using the `ollama/ollama:latest` image.
* Configured a `web` service to expose the Ollama container on TCP port 11434, mapping it to the host.